### PR TITLE
Improve visibility of type check setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,8 @@ The latest version of the extension can be installed from the VSCode [marketplac
 | Name 	| Description 	| Default 	|
 |---	|---	|---	|
 | workspace.filterPredictionsEnabled 	| If enabled, based on the file's imported names, irrelevent type predictions will be filtered out. Disable this setting if you would like to get all the predicted types regardless of relevancy. 	| true 	|
-| workspace.typeCheckEnabled 	| If enabled, type checking will be performed for predicted types. This will result in longer waiting times, but will lead to more precise type suggestions. **[Not supported yet!]** 	| false 	|
+| workspace.typeCheckEnabled 	| **[NOT SUPPORTED YET!]** If enabled, type checking will be performed for predicted types. This will result in longer waiting times, but will lead to more precise type suggestions. | false 	|
 | workspace.shareAcceptedPredictions | If enabled, accepted type predictions will be shared with us for research purposes and improving our Type4Py model. Note that the value of VSCode Telemetry overrides this setting. Read our privacy statement [here](PRIVACY.md). | false
-
 
 # Privacy
 Privacy is very prominent for us. You can read our privacy statements [here](PRIVACY.md).

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 				"workspace.typeCheckEnabled": {
 					"type": "boolean",
 					"default": false,
-					"description": "If enabled, type checking will be performed for predicted types. This will result in longer waiting times, but will lead to more precise type suggestions. [Not supported yet!]"
+					"description": " [NOT SUPPORTED YET!] If enabled, type checking will be performed for predicted types. This will result in longer waiting times, but will lead to more precise type suggestions."
 				},
 				"workspace.filterPredictionsEnabled": {
 					"type": "boolean",


### PR DESCRIPTION
Suggestion to improve the visibility of the `typeCheck` setting by adding the disclaimer at the beginning of the command so the user immediately sees the message.