### PR TITLE
Allow whitespace after annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ This extension provides machine learning-based type autocompletion for Python, w
 - [Settings](#settings)
 - [Privacy](#privacy)
 - [Limitations](#limitations)
-- [Known Issues](#known-issues)
 - [Design](#design)
 - [Support](#support)
 - [Development](#development)
@@ -61,8 +60,7 @@ To accommodate fair use and availability for all users, the extension has curren
 <!-- - **Rate limit**: 5 requests per hour and 100 requests per day. -->
 - **File size**: Python source files of up to 1K LoC can be processed.
 
-# Known Issues
-- When performing type autocompletion, a space after annotation syntax symbols like `:` or `->` changes the list of predicted types based on the matched pattern.
+<!-- # Known Issues -->
 
 # Design
 ![](images/design.png)

--- a/src/completionProvider.ts
+++ b/src/completionProvider.ts
@@ -292,7 +292,8 @@ function annotationToCompletionItem(annotation: string, id: number, typeSlot: Ty
                                     identifierName: string, typeSlotLineNo: number): CompletionItem {
     const item = new CompletionItem(annotation, CompletionItemKind.TypeParameter);
     item.command = new AcceptedTypeCompletionItem(annotation, id, typeSlot, identifierName, typeSlotLineNo);
-    
+    item.filterText = ` ${item.label}`; // Do not remove filter after adding single whitespace
+    item.insertText = ` ${item.label}`; // Add whitespace after annotation
     item.sortText = `${id}`;
     return item;
 }


### PR DESCRIPTION
Addresses #9 issue by allowing 1 whitespace character for annotations.

The solution is quite hacky, but unfortunately seems to be the only workaround right now due to spaces not being treated as trigger characters (thus not triggering the completion provider). See also [issue](https://github.com/microsoft/vscode/issues/69542)