### PR TITLE
Capture canceled type predictions by the user + submission

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ import { INFER_REQUEST_TIMEOUT, INFER_URL_BASE, INFER_URL_BASE_DEV, TELEMETRY_RE
 import * as fs from 'fs';
 import { ERROR_MESSAGES } from './messages';
 import * as path from 'path';
+import { commands } from 'vscode';
 
 
 // Called when the extension is activated.
@@ -34,8 +35,6 @@ export function activate(context: vscode.ExtensionContext) {
             paramHintTrigger
         ),
     );
-
-    
 
     // Register command for inferring type hints
     const inferCommand = vscode.commands.registerCommand('type4py.infer', async () => { infer(settings, context) });
@@ -169,6 +168,14 @@ async function infer(settings: Type4PySettings, context: vscode.ExtensionContext
                     vscode.window.showErrorMessage(ERROR_MESSAGES.emptyPayload);
                 }
             } else {
+                
+                // Submitting the last cancelled prediciton based on the user's consent 
+                // before giving new predictions.
+                if (context.workspaceState.get("lastTypePrediction") !== null) {
+                    commands.executeCommand("submitAcceptedType",
+                                    context!.workspaceState.get("lastTypePrediction"));
+                }
+
                 // Transform & cache API data
                 const inferResultData: InferApiData = inferResult.data.response;
                 const transformedInferResultData = transformInferApiData(inferResultData);
@@ -187,7 +194,6 @@ async function infer(settings: Type4PySettings, context: vscode.ExtensionContext
             }
         } catch (error) {
             console.error(error);
-
             if (error.message) {
                 vscode.window.showErrorMessage(error.message);
             }                

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,16 +60,31 @@ export function activate(context: vscode.ExtensionContext) {
             } else {
                 telemetry_url = TELEMETRY_URL_BASE;
             }
-            const telemResult = axios.get(telemetry_url,
-                {timeout: TELEMETRY_REQ_TIMEOUT , params: {
+
+            var req_params;
+            if (acceptedType !== null && rank !== null) {
+                req_params = {
                     at: acceptedType,
                     r: rank,
                     ts: typeSlot,
+                    cp: 0,
                     fp: settings.fliterPredsEnabled ? 1 : 0,
                     idn: identifierName,
                     tsl: typeSlotLineNo,
                     sid: context.workspaceState.get(path.parse(vscode.workspace.asRelativePath(f)).base) 
-                    }}
+                }
+            } else {
+                req_params = {
+                    ts: typeSlot,
+                    cp: 1,
+                    fp: settings.fliterPredsEnabled ? 1 : 0,
+                    idn: identifierName,
+                    tsl: typeSlotLineNo,
+                    sid: context.workspaceState.get(path.parse(vscode.workspace.asRelativePath(f)).base) 
+                    }
+            }
+            const telemResult = axios.get(telemetry_url,
+                {timeout: TELEMETRY_REQ_TIMEOUT , params: req_params}
                 );
        }
        

--- a/test/suite/providers/completionProvider.test.ts
+++ b/test/suite/providers/completionProvider.test.ts
@@ -5,7 +5,7 @@ import { CompletionProvider, ParamHintCompletionProvider } from "../../../src/co
 import { messageFor } from '../../common';
 
 suite('ParamHintCompletionProvider', () => {
-    const provider = new ParamHintCompletionProvider();
+    const provider = new ParamHintCompletionProvider(null);
 
     test("provides items for first param", async () => {
         let param = "param_1:";


### PR DESCRIPTION
- Based on the user's consent, the extension now submits canceled type predictions for variables, parameters, and return types by the user.
- Each time the user invokes type auto-completion, it checks whether the previous prediction was accepted or not. If not, it'll be submitted to the server.

## Trigger Events
Events that trigger the submission of canceled predictions:
- Invoking type auto-completion at another type slot without accepting a type prediction.
- Invoking infer command
- Closing a Python file or changing the currently opened file (not implemented in this PR).

## Testing
- [x] Cancellation for variables prediction
- [x] Cancellation for parameters prediction
- [x] Cancellation for return types prediction