### PR TITLE
Multi-variable in function support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to the [Type4Py's VSCode extension](https://github.com/saltudelft/type4py-vscode-ext) will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.4] - 2021-07-21
 ### Added
 - Detecting `ExtensionMode` for testing and development using the local server (**ONLY FOR THE EXTENSION'S DEVELOPERS**).
 - Submitting the canceled/rejected type predictions based on the user's consent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to the [Type4Py's VSCode extension](https://github.com/saltudelft/type4py-vscode-ext) will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- A naive support for predicting types in the case of variables redeclaration in the scope of functions (Addresses #7).
 
 ## [0.1.4] - 2021-07-21
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # VSCode Extension of Type4Py
+[![vsm-version](https://img.shields.io/visual-studio-marketplace/v/saltud.type4py?style=flat&label=VS%20Marketplace&logo=visual-studio-code)](https://marketplace.visualstudio.com/items?itemName=saltud.type4py)
+
 This extension provides machine learning-based type autocompletion for Python, which assists developers to gradually add type annotations to their existing codebases.
 
 - [Core Features](#core-features)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "type4py",
 	"displayName": "Type4Py",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"description": "Machine learning-based type autocompletion for Python",
 	"icon": "images/icon.ico",
 	"publisher": "saltud",

--- a/python/sample_files/func_multi_var.py
+++ b/python/sample_files/func_multi_var.py
@@ -1,3 +1,17 @@
+class A():
+    def __init__(self):
+        x = 1
+    
+    def sign(self, y):
+        if y < 0:
+            sign = "-"
+        elif y == 0:
+            sign = ""
+        else:
+            sign = "+"
+        
+        return sign
+
 def fun(a):
     if a:
         x = 1

--- a/src/type4pyData.ts
+++ b/src/type4pyData.ts
@@ -131,14 +131,14 @@ export function transformInferApiData(apiData: InferApiData): InferData {
     variableInferData.push(...extractVariableInferData(
         apiData.variables_p, 
         apiData.mod_var_ln
-    ))
+    ));
 
     // Merge class functions & variables
     for (const apiClass of apiData.classes) {
         funcs = funcs.concat(apiClass.funcs);
         variableInferData.push(...extractVariableInferData(
             apiClass.variables_p, apiClass.cls_var_ln
-        ))
+        ));
     }
 
     // Collect functions & function variables
@@ -166,9 +166,20 @@ export function transformInferApiData(apiData: InferApiData): InferData {
         };
 
         functionInferData.push(funcEntry);
+
+        // Workaround: set every variable location to the function location,
+        // essentially ensuring the API decides the variable annotation based
+        // on the key (name) of the variable.
+        // This allows multiple variables with the same identifier in function
+        // scope to have the same annotations.
+        const varLocations: InferApiVarLocations = {};
+        for (const loc of Object.keys(func.fn_var_ln)) {
+            varLocations[loc] = func.fn_lc;
+        }
+
         variableInferData.push(...extractVariableInferData(
-            func.variables_p, func.fn_var_ln
-        ))
+            func.variables_p, varLocations
+        ));
     }
 
     return {


### PR DESCRIPTION
Workaround to support multi-variable declarations in functions.

Note that this does not fully address the issue (i.e. in the case of module-level variables), in the future this would have to be integrated server-side or via use of fully-qualified names, but for now it solves the issue found in #7.