### PR TITLE
Adding a setting to query the local model of Type4Py for type inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to the [Type4Py's VSCode extension](https://github.com/saltudelft/type4py-vscode-ext) will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- A setting, `workspace.localModelEnabled`, to query the local model of Type4Py on users' machines for type inference ([#24](https://github.com/saltudelft/type4py-vscode-ext/pull/24)).
 
 ## [0.1.6] - 2021-09-01
 ### Added

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -5,6 +5,8 @@ We do respect our users' privacy and want to clarify that:
 
 With regards to the above-defined statements, to improve our Type4Py model and conduct research, we collect two kinds of telemetry data which are described below.
 
+> **NOTE**: If Type4Py's local model is used, no telemetry data is sent to any external server.
+
 # Telemetry
 ## Prediction requests:
   - **Hashed IP addresses**: Helps to uniquely identify prediction requests and active users. Note that a hashed IP cannot be decoded and makes users anonymous. E.g. `8a0872388f0f1...`

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ This extension provides machine learning-based type autocompletion for Python, w
 
 # Core Features
 - **Machine learning**-based type prediction (powered by [Type4Py](https://github.com/saltudelft/type4py))
+- It can be used with a **local model** on your machine (No data sharing) 
 - Improved **autocompletion** for Python type annotations (based on [Python Type Hint](https://github.com/njqdev/vscode-python-typehint))
-- Type autocompletion for **parameters** and **return types** of functions.
-- Type autocompletion for module, class, and local **variables**.
+- Type autocompletion for **parameters**, **return types** of functions, and **variables**.
 - Simple, fairly fast and easy to use.
 
 # Usage
@@ -36,6 +36,8 @@ This extension provides machine learning-based type autocompletion for Python, w
 4. After the completion of your request, you can now start adding predicted type annotations to your code, similar to the [Quick Start](#quick-start) example above.
 
 > **Tip:** At the bottom left of VSCode, click on the status bar of Type4py to see the extension's logs and errors.
+
+> **Tip:** To use the local model for type inference instead of our server, see [settings](#settings).
 
 > **Tip:** You can also enable automatic type inference when opening Python files. To do so, see [settings](#settings).
 
@@ -54,6 +56,7 @@ The latest version of the extension can be installed from the [Visual Studio Mar
 # Settings
 | Name 	| Description 	| Default 	|
 |---	|---	|---	|
+| workspace.localModelEnabled | If enabled, it uses Type4Py's local model on your machine. NOTE THAT you need to pull and run Type4Py's Docker image first. See [here](https://github.com/saltudelft/type4py/wiki/Type4Py's-Local-Model) for more info. | false |
 | workspace.autoInferEnabled | If enabled, it automatically infers type annotations when opening a Python source file. Note that automatic inference works only once for a newly opened file. | false |
 | workspace.filterPredictionsEnabled 	| If enabled, based on the file's imported names, irrelevent type predictions will be filtered out. Disable this setting if you would like to get all the predicted types regardless of relevancy. 	| true 	|
 | workspace.shareAcceptedPredictions | If enabled, accepted type predictions will be shared with us for research purposes and improving our Type4Py model. Note that the value of VSCode Telemetry overrides this setting. Read our privacy statement [here](PRIVACY.md). | false
@@ -99,7 +102,6 @@ Here are the desirable features for future releases.
 - Implementing a caching solution to preserve type predictions when source files change.
 - Enabling the type-checking process for the Type4Py's predictions using [mypy](https://github.com/python/mypy), preferably at the client-side.
 - Fine-tuning the (pre-trained) Type4Py model on users' projects to learn project-specific types.
-- Releasing a local version of the Type4Py model and its pipeline that can be queried on users' machines.
 
 # Contributors
 - Amir M. Mir (@mir-am)

--- a/package.json
+++ b/package.json
@@ -54,6 +54,11 @@
 		"configuration": {
 			"title": "Type4Py",
 			"properties": {
+				"workspace.localModelEnabled": {
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "If enabled, it uses Type4Py's local model on your machine. NOTE THAT you need to pull and run Type4Py's Docker image first. See [here](https://github.com/saltudelft/type4py/wiki/Type4Py's-Local-Model) for more info."
+				},
 				"workspace.autoInferEnabled": {
 					"type": "boolean",
 					"default": false,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,7 @@
 export const INFER_URL_BASE = `https://type4py.com/api/predict`;
 export const INFER_URL_BASE_DEV = `https://dev.type4py.com/api/predict`;
+export const INFER_URL_BASE_LOCAL = `http://localhost:5001/api/predict`;
+
 export const TELEMETRY_URL_BASE = `https://type4py.com/api/telemetry/accept_type`;
 export const TELEMETRY_URL_BASE_DEV = `https://dev.type4py.com/api/telemetry/accept_type`;
 

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -5,7 +5,8 @@ export const ERROR_MESSAGES = {
     'nonPythonFile': "Cannot infer type annotations for non-Python code files.",
     'emptyFile': "Cannot infer type annotations for empty files.",
     'emptyPayload': "The received response was empty.",
-    'connectionError': "Could not connect to the server."
+    'connectionError': "Could not connect to the server.",
+    'localModelNotDetected': "Could not use the local model. Ensure that Type4Py's Docker container is running." 
 };
 
 export const TELEMETRY_REQUEST_MESSAGE = "Would you like to share accepted " +

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -9,6 +9,7 @@ export class Type4PySettings {
     private _filterPreds = true;
     private _shareAcceptedPreds = false;
     private _autoInfer = false;
+    private _useLocalModel = false;
 
     constructor() {
         workspace.onDidChangeConfiguration(() => {
@@ -33,6 +34,10 @@ export class Type4PySettings {
         return this._autoInfer;
     }
 
+    public get useLocalModel() {
+        return this._useLocalModel;
+    }
+
     public set setShareAcceptedPreds(value: boolean) {
         this._shareAcceptedPreds = value;
     }
@@ -52,6 +57,8 @@ export class Type4PySettings {
             .getConfiguration('workspace').get('shareAcceptedPredictions');
         const autoInfer: boolean | undefined = workspace
             .getConfiguration('workspace').get('autoInferEnabled');
+        const useLocalModel: boolean | undefined = workspace
+            .getConfiguration('workspace').get('localModelEnabled');
         
         // if (tcEnable !== undefined) {
         //     this._tcEnabled = tcEnable;
@@ -67,6 +74,10 @@ export class Type4PySettings {
 
         if (autoInfer !== undefined) {
             this._autoInfer = autoInfer;
+        }
+
+        if (useLocalModel !== undefined) {
+            this._useLocalModel = useLocalModel;
         }
     }
 }

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -13,9 +13,9 @@ export class Type4PyOutputChannel {
         context.subscriptions.push(this.outputChannel);
     }
 
-    public appendInProgress(fileName: string) {
+    public appendInProgress(fileName: string, isLocalModelUsed: boolean) {
         this.outputChannel.appendLine(
-            `[${new Date().toLocaleString()}][${fileName}] Inferring types...`
+            `[${new Date().toLocaleString()}][${fileName}] Inferring types using ${(isLocalModelUsed) ? ('local model') : ('central server')}...`
         );
     }
 


### PR DESCRIPTION
In this PR, a new setting, `workspace.localModelEnabled`, is added to the extension. This enables users to use the local model of Type4Py on their machines for type inference. This way, no data is sent to any external server and it should address users' possible privacy concerns. The local model is run in a Docker container and is exposed at `localhost:5001`.