### PR TITLE
Fix Build Process

### DIFF
--- a/.github/workflows/publish_vsce.yaml
+++ b/.github/workflows/publish_vsce.yaml
@@ -20,8 +20,5 @@ jobs:
       - name: Install the dependencies
         run: npm i
 
-      - name: Install vsce
-        run: npm i -g vsce
-
       - name: Publish
-        run: vsce publish -p ${{ secrets.VSCE_PAT }}
+        run: npx vsce publish -p ${{ secrets.VSCE_PAT }}

--- a/.github/workflows/publish_vsce.yaml
+++ b/.github/workflows/publish_vsce.yaml
@@ -20,9 +20,6 @@ jobs:
       - name: Install the dependencies
         run: npm i
 
-      - name: Compile the extension
-        run: npm run compile && npm run compile-web
-
       - name: Install vsce
         run: npm i -g vsce
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,8 +37,8 @@
 				"typescript": "^3.9.7",
 				"url-parse": "^1.5.6",
 				"vscode-test": "^1.6.1",
-				"webpack": "^5.38.1",
-				"webpack-cli": "^4.7.0"
+				"webpack": "^5.70.0",
+				"webpack-cli": "^4.9.2"
 			},
 			"engines": {
 				"vscode": "^1.59.0"
@@ -129,9 +129,9 @@
 			}
 		},
 		"node_modules/@types/eslint": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.0.tgz",
-			"integrity": "sha512-07XlgzX0YJUn4iG1ocY4IX9DzKSmMGUs6ESKlxWhZRaa0fatIWaHWUVapcuGa8r5HFnTqzj+4OCjd5f7EZ/i/A==",
+			"version": "8.4.1",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
+			"integrity": "sha512-GE44+DNEyxxh2Kc6ro/VkIj+9ma0pO0bwv9+uHSyBrikYOHr8zYcdPvnBOp1aw8s+CjRvuSx7CyWqRrNFQ59mA==",
 			"dev": true,
 			"dependencies": {
 				"@types/estree": "*",
@@ -139,9 +139,9 @@
 			}
 		},
 		"node_modules/@types/eslint-scope": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.1.tgz",
-			"integrity": "sha512-SCFeogqiptms4Fg29WpOTk5nHIzfpKCemSN63ksBQYKTcXoJEmJagV+DhVmbapZzY4/5YaOV1nZwrsU79fFm1g==",
+			"version": "3.7.3",
+			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.3.tgz",
+			"integrity": "sha512-PB3ldyrcnAicT35TWPs5IcwKD8S333HMaa2VVv4+wdvebJkjWuW/xESoB8IwRcog8HYVYamb1g/R31Qv5Bx03g==",
 			"dev": true,
 			"dependencies": {
 				"@types/eslint": "*",
@@ -155,9 +155,9 @@
 			"dev": true
 		},
 		"node_modules/@types/estree": {
-			"version": "0.0.50",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-			"integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
+			"version": "0.0.51",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+			"integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
 			"dev": true
 		},
 		"node_modules/@types/glob": {
@@ -499,9 +499,9 @@
 			}
 		},
 		"node_modules/@webpack-cli/configtest": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.0.4.tgz",
-			"integrity": "sha512-cs3XLy+UcxiP6bj0A6u7MLLuwdXJ1c3Dtc0RkKg+wiI1g/Ti1om8+/2hc2A2B60NbBNAbMgyBMHvyymWm/j4wQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.1.tgz",
+			"integrity": "sha512-1FBc1f9G4P/AxMqIgfZgeOTuRnwZMten8E7zap5zgpPInnCrP8D4Q81+4CWIch8i/Nf7nXjP0v6CjjbHOrXhKg==",
 			"dev": true,
 			"peerDependencies": {
 				"webpack": "4.x.x || 5.x.x",
@@ -509,9 +509,9 @@
 			}
 		},
 		"node_modules/@webpack-cli/info": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.3.0.tgz",
-			"integrity": "sha512-ASiVB3t9LOKHs5DyVUcxpraBXDOKubYu/ihHhU+t1UPpxsivg6Od2E2qU4gJCekfEddzRBzHhzA/Acyw/mlK/w==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.1.tgz",
+			"integrity": "sha512-PKVGmazEq3oAo46Q63tpMr4HipI3OPfP7LiNOEJg963RMgT0rqheag28NCML0o3GIzA3DmxP1ZIAv9oTX1CUIA==",
 			"dev": true,
 			"dependencies": {
 				"envinfo": "^7.7.3"
@@ -521,9 +521,9 @@
 			}
 		},
 		"node_modules/@webpack-cli/serve": {
-			"version": "1.5.2",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.5.2.tgz",
-			"integrity": "sha512-vgJ5OLWadI8aKjDlOH3rb+dYyPd2GTZuQC/Tihjct6F9GpXGZINo3Y/IVuZVTM1eDQB+/AOsjPUWH/WySDaXvw==",
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.1.tgz",
+			"integrity": "sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==",
 			"dev": true,
 			"peerDependencies": {
 				"webpack-cli": "4.x.x"
@@ -1806,9 +1806,9 @@
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.8.2",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz",
-			"integrity": "sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==",
+			"version": "5.9.2",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.2.tgz",
+			"integrity": "sha512-GIm3fQfwLJ8YZx2smuHpBKkXC1yOk+OBEmKckVyL0i/ea8mqDEykK3ld5dgH1QYPNyT/lIllxV2LULnxCHaHkA==",
 			"dev": true,
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
@@ -1831,9 +1831,9 @@
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.7.1.tgz",
-			"integrity": "sha512-MgtWFl5No+4S3TmhDmCz2ObFGm6lEpTnzbQi+Dd+pw4mlTIZTmM2iAs5gRlmx5zS9luzobCSBSI90JM/1/JgOw==",
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
+			"integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
 			"dev": true
 		},
 		"node_modules/escalade": {
@@ -2534,9 +2534,9 @@
 			}
 		},
 		"node_modules/graceful-fs": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-			"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+			"version": "4.2.9",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
+			"integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
 			"dev": true
 		},
 		"node_modules/growl": {
@@ -5514,9 +5514,9 @@
 			"dev": true
 		},
 		"node_modules/watchpack": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
-			"integrity": "sha512-up4YAn/XHgZHIxFBVCdlMiWDj6WaLKpwVeGQk2I5thdYxF/KmF0aaz6TfJZ/hfl1h/XlcDr7k1KH7ThDagpFaA==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.3.1.tgz",
+			"integrity": "sha512-x0t0JuydIo8qCNctdDrn1OzH/qDzk2+rdCOC3YzumZ42fiMqmQ7T3xQurykYMhYfHaPHTp4ZxAx2NfUo1K6QaA==",
 			"dev": true,
 			"dependencies": {
 				"glob-to-regexp": "^0.4.1",
@@ -5532,13 +5532,13 @@
 			"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
 		},
 		"node_modules/webpack": {
-			"version": "5.51.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.51.1.tgz",
-			"integrity": "sha512-xsn3lwqEKoFvqn4JQggPSRxE4dhsRcysWTqYABAZlmavcoTmwlOb9b1N36Inbt/eIispSkuHa80/FJkDTPos1A==",
+			"version": "5.70.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.70.0.tgz",
+			"integrity": "sha512-ZMWWy8CeuTTjCxbeaQI21xSswseF2oNOwc70QSKNePvmxE7XW36i7vpBMYZFAUHPwQiEbNGCEYIOOlyRbdGmxw==",
 			"dev": true,
 			"dependencies": {
-				"@types/eslint-scope": "^3.7.0",
-				"@types/estree": "^0.0.50",
+				"@types/eslint-scope": "^3.7.3",
+				"@types/estree": "^0.0.51",
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/wasm-edit": "1.11.1",
 				"@webassemblyjs/wasm-parser": "1.11.1",
@@ -5546,12 +5546,12 @@
 				"acorn-import-assertions": "^1.7.6",
 				"browserslist": "^4.14.5",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.8.0",
-				"es-module-lexer": "^0.7.1",
+				"enhanced-resolve": "^5.9.2",
+				"es-module-lexer": "^0.9.0",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
 				"glob-to-regexp": "^0.4.1",
-				"graceful-fs": "^4.2.4",
+				"graceful-fs": "^4.2.9",
 				"json-parse-better-errors": "^1.0.2",
 				"loader-runner": "^4.2.0",
 				"mime-types": "^2.1.27",
@@ -5559,8 +5559,8 @@
 				"schema-utils": "^3.1.0",
 				"tapable": "^2.1.1",
 				"terser-webpack-plugin": "^5.1.3",
-				"watchpack": "^2.2.0",
-				"webpack-sources": "^3.2.0"
+				"watchpack": "^2.3.1",
+				"webpack-sources": "^3.2.3"
 			},
 			"bin": {
 				"webpack": "bin/webpack.js"
@@ -5579,23 +5579,22 @@
 			}
 		},
 		"node_modules/webpack-cli": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.8.0.tgz",
-			"integrity": "sha512-+iBSWsX16uVna5aAYN6/wjhJy1q/GKk4KjKvfg90/6hykCTSgozbfz5iRgDTSJt/LgSbYxdBX3KBHeobIs+ZEw==",
+			"version": "4.9.2",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.2.tgz",
+			"integrity": "sha512-m3/AACnBBzK/kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==",
 			"dev": true,
 			"dependencies": {
 				"@discoveryjs/json-ext": "^0.5.0",
-				"@webpack-cli/configtest": "^1.0.4",
-				"@webpack-cli/info": "^1.3.0",
-				"@webpack-cli/serve": "^1.5.2",
-				"colorette": "^1.2.1",
+				"@webpack-cli/configtest": "^1.1.1",
+				"@webpack-cli/info": "^1.4.1",
+				"@webpack-cli/serve": "^1.6.1",
+				"colorette": "^2.0.14",
 				"commander": "^7.0.0",
 				"execa": "^5.0.0",
 				"fastest-levenshtein": "^1.0.12",
 				"import-local": "^3.0.2",
 				"interpret": "^2.2.0",
 				"rechoir": "^0.7.0",
-				"v8-compile-cache": "^2.2.0",
 				"webpack-merge": "^5.7.3"
 			},
 			"bin": {
@@ -5622,6 +5621,12 @@
 				}
 			}
 		},
+		"node_modules/webpack-cli/node_modules/colorette": {
+			"version": "2.0.16",
+			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+			"integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+			"dev": true
+		},
 		"node_modules/webpack-cli/node_modules/commander": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
@@ -5645,9 +5650,9 @@
 			}
 		},
 		"node_modules/webpack-sources": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.0.tgz",
-			"integrity": "sha512-fahN08Et7P9trej8xz/Z7eRu8ltyiygEo/hnRi9KqBUs80KeDcnf96ZJo++ewWd84fEf3xSX9bp4ZS9hbw0OBw==",
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+			"integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
 			"dev": true,
 			"engines": {
 				"node": ">=10.13.0"
@@ -6001,9 +6006,9 @@
 			}
 		},
 		"@types/eslint": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.0.tgz",
-			"integrity": "sha512-07XlgzX0YJUn4iG1ocY4IX9DzKSmMGUs6ESKlxWhZRaa0fatIWaHWUVapcuGa8r5HFnTqzj+4OCjd5f7EZ/i/A==",
+			"version": "8.4.1",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
+			"integrity": "sha512-GE44+DNEyxxh2Kc6ro/VkIj+9ma0pO0bwv9+uHSyBrikYOHr8zYcdPvnBOp1aw8s+CjRvuSx7CyWqRrNFQ59mA==",
 			"dev": true,
 			"requires": {
 				"@types/estree": "*",
@@ -6011,9 +6016,9 @@
 			}
 		},
 		"@types/eslint-scope": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.1.tgz",
-			"integrity": "sha512-SCFeogqiptms4Fg29WpOTk5nHIzfpKCemSN63ksBQYKTcXoJEmJagV+DhVmbapZzY4/5YaOV1nZwrsU79fFm1g==",
+			"version": "3.7.3",
+			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.3.tgz",
+			"integrity": "sha512-PB3ldyrcnAicT35TWPs5IcwKD8S333HMaa2VVv4+wdvebJkjWuW/xESoB8IwRcog8HYVYamb1g/R31Qv5Bx03g==",
 			"dev": true,
 			"requires": {
 				"@types/eslint": "*",
@@ -6027,9 +6032,9 @@
 			"dev": true
 		},
 		"@types/estree": {
-			"version": "0.0.50",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-			"integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
+			"version": "0.0.51",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+			"integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
 			"dev": true
 		},
 		"@types/glob": {
@@ -6312,25 +6317,25 @@
 			}
 		},
 		"@webpack-cli/configtest": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.0.4.tgz",
-			"integrity": "sha512-cs3XLy+UcxiP6bj0A6u7MLLuwdXJ1c3Dtc0RkKg+wiI1g/Ti1om8+/2hc2A2B60NbBNAbMgyBMHvyymWm/j4wQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.1.tgz",
+			"integrity": "sha512-1FBc1f9G4P/AxMqIgfZgeOTuRnwZMten8E7zap5zgpPInnCrP8D4Q81+4CWIch8i/Nf7nXjP0v6CjjbHOrXhKg==",
 			"dev": true,
 			"requires": {}
 		},
 		"@webpack-cli/info": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.3.0.tgz",
-			"integrity": "sha512-ASiVB3t9LOKHs5DyVUcxpraBXDOKubYu/ihHhU+t1UPpxsivg6Od2E2qU4gJCekfEddzRBzHhzA/Acyw/mlK/w==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.1.tgz",
+			"integrity": "sha512-PKVGmazEq3oAo46Q63tpMr4HipI3OPfP7LiNOEJg963RMgT0rqheag28NCML0o3GIzA3DmxP1ZIAv9oTX1CUIA==",
 			"dev": true,
 			"requires": {
 				"envinfo": "^7.7.3"
 			}
 		},
 		"@webpack-cli/serve": {
-			"version": "1.5.2",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.5.2.tgz",
-			"integrity": "sha512-vgJ5OLWadI8aKjDlOH3rb+dYyPd2GTZuQC/Tihjct6F9GpXGZINo3Y/IVuZVTM1eDQB+/AOsjPUWH/WySDaXvw==",
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.1.tgz",
+			"integrity": "sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==",
 			"dev": true,
 			"requires": {}
 		},
@@ -7388,9 +7393,9 @@
 			}
 		},
 		"enhanced-resolve": {
-			"version": "5.8.2",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz",
-			"integrity": "sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==",
+			"version": "5.9.2",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.2.tgz",
+			"integrity": "sha512-GIm3fQfwLJ8YZx2smuHpBKkXC1yOk+OBEmKckVyL0i/ea8mqDEykK3ld5dgH1QYPNyT/lIllxV2LULnxCHaHkA==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.2.4",
@@ -7404,9 +7409,9 @@
 			"dev": true
 		},
 		"es-module-lexer": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.7.1.tgz",
-			"integrity": "sha512-MgtWFl5No+4S3TmhDmCz2ObFGm6lEpTnzbQi+Dd+pw4mlTIZTmM2iAs5gRlmx5zS9luzobCSBSI90JM/1/JgOw==",
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
+			"integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
 			"dev": true
 		},
 		"escalade": {
@@ -7919,9 +7924,9 @@
 			}
 		},
 		"graceful-fs": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-			"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+			"version": "4.2.9",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
+			"integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
 			"dev": true
 		},
 		"growl": {
@@ -10232,9 +10237,9 @@
 			"dev": true
 		},
 		"watchpack": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
-			"integrity": "sha512-up4YAn/XHgZHIxFBVCdlMiWDj6WaLKpwVeGQk2I5thdYxF/KmF0aaz6TfJZ/hfl1h/XlcDr7k1KH7ThDagpFaA==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.3.1.tgz",
+			"integrity": "sha512-x0t0JuydIo8qCNctdDrn1OzH/qDzk2+rdCOC3YzumZ42fiMqmQ7T3xQurykYMhYfHaPHTp4ZxAx2NfUo1K6QaA==",
 			"dev": true,
 			"requires": {
 				"glob-to-regexp": "^0.4.1",
@@ -10247,13 +10252,13 @@
 			"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
 		},
 		"webpack": {
-			"version": "5.51.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.51.1.tgz",
-			"integrity": "sha512-xsn3lwqEKoFvqn4JQggPSRxE4dhsRcysWTqYABAZlmavcoTmwlOb9b1N36Inbt/eIispSkuHa80/FJkDTPos1A==",
+			"version": "5.70.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.70.0.tgz",
+			"integrity": "sha512-ZMWWy8CeuTTjCxbeaQI21xSswseF2oNOwc70QSKNePvmxE7XW36i7vpBMYZFAUHPwQiEbNGCEYIOOlyRbdGmxw==",
 			"dev": true,
 			"requires": {
-				"@types/eslint-scope": "^3.7.0",
-				"@types/estree": "^0.0.50",
+				"@types/eslint-scope": "^3.7.3",
+				"@types/estree": "^0.0.51",
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/wasm-edit": "1.11.1",
 				"@webassemblyjs/wasm-parser": "1.11.1",
@@ -10261,12 +10266,12 @@
 				"acorn-import-assertions": "^1.7.6",
 				"browserslist": "^4.14.5",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.8.0",
-				"es-module-lexer": "^0.7.1",
+				"enhanced-resolve": "^5.9.2",
+				"es-module-lexer": "^0.9.0",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
 				"glob-to-regexp": "^0.4.1",
-				"graceful-fs": "^4.2.4",
+				"graceful-fs": "^4.2.9",
 				"json-parse-better-errors": "^1.0.2",
 				"loader-runner": "^4.2.0",
 				"mime-types": "^2.1.27",
@@ -10274,8 +10279,8 @@
 				"schema-utils": "^3.1.0",
 				"tapable": "^2.1.1",
 				"terser-webpack-plugin": "^5.1.3",
-				"watchpack": "^2.2.0",
-				"webpack-sources": "^3.2.0"
+				"watchpack": "^2.3.1",
+				"webpack-sources": "^3.2.3"
 			},
 			"dependencies": {
 				"acorn": {
@@ -10294,26 +10299,31 @@
 			}
 		},
 		"webpack-cli": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.8.0.tgz",
-			"integrity": "sha512-+iBSWsX16uVna5aAYN6/wjhJy1q/GKk4KjKvfg90/6hykCTSgozbfz5iRgDTSJt/LgSbYxdBX3KBHeobIs+ZEw==",
+			"version": "4.9.2",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.2.tgz",
+			"integrity": "sha512-m3/AACnBBzK/kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==",
 			"dev": true,
 			"requires": {
 				"@discoveryjs/json-ext": "^0.5.0",
-				"@webpack-cli/configtest": "^1.0.4",
-				"@webpack-cli/info": "^1.3.0",
-				"@webpack-cli/serve": "^1.5.2",
-				"colorette": "^1.2.1",
+				"@webpack-cli/configtest": "^1.1.1",
+				"@webpack-cli/info": "^1.4.1",
+				"@webpack-cli/serve": "^1.6.1",
+				"colorette": "^2.0.14",
 				"commander": "^7.0.0",
 				"execa": "^5.0.0",
 				"fastest-levenshtein": "^1.0.12",
 				"import-local": "^3.0.2",
 				"interpret": "^2.2.0",
 				"rechoir": "^0.7.0",
-				"v8-compile-cache": "^2.2.0",
 				"webpack-merge": "^5.7.3"
 			},
 			"dependencies": {
+				"colorette": {
+					"version": "2.0.16",
+					"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+					"integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+					"dev": true
+				},
 				"commander": {
 					"version": "7.2.0",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
@@ -10333,9 +10343,9 @@
 			}
 		},
 		"webpack-sources": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.0.tgz",
-			"integrity": "sha512-fahN08Et7P9trej8xz/Z7eRu8ltyiygEo/hnRi9KqBUs80KeDcnf96ZJo++ewWd84fEf3xSX9bp4ZS9hbw0OBw==",
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+			"integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
 			"dev": true
 		},
 		"whatwg-url": {

--- a/package.json
+++ b/package.json
@@ -115,8 +115,8 @@
 		"typescript": "^3.9.7",
 		"url-parse": "^1.5.6",
 		"vscode-test": "^1.6.1",
-		"webpack": "^5.38.1",
-		"webpack-cli": "^4.7.0"
+		"webpack": "^5.70.0",
+		"webpack-cli": "^4.9.2"
 	},
 	"dependencies": {
 		"axios": "^0.21.2",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
 	"scripts": {
 		"package": "vsce package",
 		"publish": "vsce publish",
-		"vscode:prepublish": "webpack --mode production",
+		"vscode:prepublish": "npm run package-web && webpack --mode production",
 		"compile": "webpack --mode none",
 		"watch": "webpack --mode none --watch",
 		"test": "tsc -p . && cp -r ./test/res ./out/test && node out/test/runTest.js",

--- a/web-extension.webpack.config.js
+++ b/web-extension.webpack.config.js
@@ -51,7 +51,8 @@ module.exports = /** @type WebpackConfig */ {
   output: {
     filename: '[name].js',
     path: path.join(__dirname, './dist/web'),
-    libraryTarget: 'commonjs'
+    libraryTarget: 'commonjs',
+    hashFunction: 'xxhash64'
   },
   devtool: 'nosources-source-map', // create a source map that points to the original source file,
   stats: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,8 @@ const config = {
     path: path.resolve(__dirname, 'dist'),
     filename: 'extension.js',
     libraryTarget: 'commonjs2',
-    devtoolModuleFilenameTemplate: '../[resource-path]'
+    devtoolModuleFilenameTemplate: '../[resource-path]',
+    hashFunction: 'xxhash64'
   },
   devtool: 'source-map',
   externals: {


### PR DESCRIPTION
As webpack doesn't support node >14 out of the box, a few changes to webpack configurations is necessary.
Furthermore, this extension doesn't compile using `vsce package`, as `dist/web/extension.js` isn't built during the execution of `vscode:prepublish`.

Changes made in this PR will make sure that webpack is using for the most recent node version and add the `package-web` script to `vscode:prepublish` in order to make sure, this extension can be compiled simply by invoking `vsce package`.