### PR TITLE
Follow-Up to #25: Remove Obsolete Workaround

### DIFF
--- a/web-extension.webpack.config.js
+++ b/web-extension.webpack.config.js
@@ -51,8 +51,7 @@ module.exports = /** @type WebpackConfig */ {
   output: {
     filename: '[name].js',
     path: path.join(__dirname, './dist/web'),
-    libraryTarget: 'commonjs',
-    hashFunction: 'xxhash64'
+    libraryTarget: 'commonjs'
   },
   devtool: 'nosources-source-map', // create a source map that points to the original source file,
   stats: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,8 +14,7 @@ const config = {
     path: path.resolve(__dirname, 'dist'),
     filename: 'extension.js',
     libraryTarget: 'commonjs2',
-    devtoolModuleFilenameTemplate: '../[resource-path]',
-    hashFunction: 'xxhash64'
+    devtoolModuleFilenameTemplate: '../[resource-path]'
   },
   devtool: 'source-map',
   externals: {


### PR DESCRIPTION
As pointed out in https://github.com/godotengine/godot-csharp-vscode/pull/41, the `hashFunction` workaround isn't necessary anymore with `webpack@5.70.0`.

Thus, this PR will undo this change I made in the last PR #25.
I'm sorry for the inconvenience.